### PR TITLE
feat: Claude Code Reviewのオプションを有効化

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,7 +55,7 @@ jobs:
             返答は日本語でお願いします。
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          use_sticky_comment: true
 
           # Optional: Customize review based on file types
           # direct_prompt: |
@@ -75,6 +75,6 @@ jobs:
           # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
 
           # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
+          if: |
+            !contains(github.event.pull_request.title, '[skip-review]') &&
+            !contains(github.event.pull_request.title, '[WIP]')


### PR DESCRIPTION
## 概要
Claude Code Reviewワークフローの便利なオプションを有効化しました。

## 変更内容

### 1. Sticky Commentの有効化
- `use_sticky_comment: true` を有効化
- 同じPRへの複数回のプッシュ時に、Claudeが同じコメントを更新するようになります
- PRのコメント欄が複数のレビューで散らからなくなります

### 2. 条件付きレビューのスキップ
- PRタイトルに `[skip-review]` または `[WIP]` が含まれる場合、レビューをスキップ
- 作業中のPRやレビュー不要なPRでCIリソースを節約できます

## メリット
- PRのコメント欄がすっきりする（履歴は保持されます）
- 必要に応じてレビューをスキップできる柔軟性

🤖 Generated with [Claude Code](https://claude.com/claude-code)