### PR TITLE
fix: skip-review条件をジョブレベルに移動 [skip-review]

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,11 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
+    # Skip review for certain conditions
+    if: |
+      !contains(github.event.pull_request.title, '[skip-review]') &&
+      !contains(github.event.pull_request.title, '[WIP]')
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -73,8 +78,3 @@ jobs:
 
           # Optional: Add specific tools for running tests or linting
           # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-
-          # Optional: Skip review for certain conditions
-          if: |
-            !contains(github.event.pull_request.title, '[skip-review]') &&
-            !contains(github.event.pull_request.title, '[WIP]')


### PR DESCRIPTION
## 概要
Claude Code Reviewワークフローの`[skip-review]`と`[WIP]`スキップ条件が正しく機能するように修正しました。

## 問題
PR #168で追加したskip-review条件がステップレベルに配置されていたため、機能していませんでした。
GitHub Actionsでは、ジョブ全体をスキップするにはジョブレベルに`if`条件を配置する必要があります。

## 変更内容
- `if`条件をステップレベル（L78-80）からジョブレベル（L22-24）に移動
- PRタイトルに`[skip-review]`または`[WIP]`が含まれる場合、ジョブ全体がスキップされるようになりました

## テスト
PR #169で動作確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)