### PR TITLE
[skip-review] chore: 小野町春香の卒業ステータスを更新

### DIFF
--- a/public/liver.json
+++ b/public/liver.json
@@ -644,7 +644,7 @@
     "aliasFirst": "おのまちはるか",
     "aliasSecond": "",
     "channelHandle": "@OnomachiHaruka",
-    "isRetire": 0,
+    "isRetire": 1,
     "isOverseas": 0,
     "birthMonth": 4,
     "birthDate": 8


### PR DESCRIPTION
## Summary
- `public/liver.json` の小野町春香（@OnomachiHaruka）の `isRetire` フラグを `0` から `1` に更新
- 卒業ステータスを反映

## Test plan
- [x] 卒業済みライバー一覧に小野町春香が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)