### PR TITLE
fix: X（Twitter）ログイン復旧のお知らせバナーと更新履歴を更新

### DIFF
--- a/app/(pages)/history/page.tsx
+++ b/app/(pages)/history/page.tsx
@@ -11,6 +11,16 @@ const Page = () => {
         <h1 className="text-3xl font-bold mb-16">更新履歴</h1>
         <div className="space-y-8">
           <div>
+            <time dateTime="2026-03-22" className="font-bold">
+              2026/03/22
+            </time>
+            <ul className="my-2 ml-6 list-disc [&>li]:mt-2">
+              <li>
+                X（Twitter）アカウントでのログインができない不具合を修正しました。
+              </li>
+            </ul>
+          </div>
+          <div>
             <time dateTime="2026-03-15" className="font-bold">
               2026/03/15
             </time>

--- a/app/(pages)/page.tsx
+++ b/app/(pages)/page.tsx
@@ -58,18 +58,18 @@ export default function Home() {
       <Suspense fallback={null}>
         <AuthSection />
       </Suspense>
-      {/* Xログイン不具合お知らせバナー */}
+      {/* Xログイン復旧お知らせバナー */}
       <div className="w-full px-4 mb-6 max-w-7xl mx-auto">
-        <div className="flex items-start gap-3 p-4 bg-yellow-50 dark:bg-yellow-950 border border-yellow-400 dark:border-yellow-600 rounded-lg text-yellow-800 dark:text-yellow-200">
-          <span className="text-xl shrink-0">⚠️</span>
+        <div className="flex items-start gap-3 p-4 bg-green-50 dark:bg-green-950 border border-green-400 dark:border-green-600 rounded-lg text-green-800 dark:text-green-200">
+          <span className="text-xl shrink-0">✅</span>
           <div>
             <p className="font-bold">
-              【障害情報】X（Twitter）ログインが現在ご利用いただけません
+              【復旧情報】X（Twitter）ログインの不具合が解消されました
             </p>
             <p className="text-sm mt-1">
-              現在、X（Twitter）アカウントでのログインに不具合が発生しています。
+              X（Twitter）アカウントでのログインが正常にご利用いただけるようになりました。
               <br />
-              Googleアカウントでのログインはご利用いただけます。ご不便をおかけして申し訳ございません。
+              ご不便をおかけして申し訳ございませんでした。
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- TOPページの障害情報バナーを復旧情報に更新（黄色→緑、⚠️→✅、テキスト変更）
- 更新履歴ページ（/history）に 2026/03/22 のエントリを追加

resolve #299

## Test plan

- [ ] TOPページにアクセスし、緑色の復旧バナーが表示されることを確認
- [ ] `/history` ページを開き、2026/03/22 の項目が先頭に表示されることを確認
- [ ] ダークモードでバナーが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)