### PR TITLE
fix: 存在しないpostIdのページで404を返すように修正

### DIFF
--- a/app/(pages)/post/[postId]/page.tsx
+++ b/app/(pages)/post/[postId]/page.tsx
@@ -11,6 +11,7 @@ import YoutubeLinkButton from "@/components/feature/post/YoutubeLinkButton";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getCachedPostById } from "./_utils/functions";
 import SkeletonPostDetailCard from "@/components/feature/post/SkeletonPostDetailCard";
+import { notFound } from "next/navigation";
 
 export async function generateMetadata(props: PageProps<"/post/[postId]">) {
   const { postId } = await props.params;
@@ -45,6 +46,9 @@ const ReactionAndReportSection = async ({ postId }: { postId: string }) => {
 
 const Page = async (props: PageProps<"/post/[postId]">) => {
   const { postId } = await props.params;
+  const post = await getCachedPostById(postId);
+
+  if (!post) notFound();
 
   return (
     <div className="grid md:grid-cols-2 max-w-7xl mx-auto md:gap-x-4 gap-y-4 px-4 w-full">


### PR DESCRIPTION
## Summary

- 存在しないpostIdのURLにアクセスした際、壊れた表示ではなく404ページを返すよう修正
- `Page` コンポーネント内で `getCachedPostById` を呼び、投稿が存在しない場合に `notFound()` を実行
- `getCachedPostById` はReactの `cache()` でラップ済みのため、`generateMetadata` との重複DBアクセスなし

Closes #211

## Test plan

- [ ] 存在しないpostId（例: `/post/nonexistent-id`）にアクセスして404ページが表示されることを確認
- [ ] 存在するpostIdにアクセスして正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)