### PR TITLE
fix: ライバー一覧ページSPで星・ハートアイコンがフッターの上に表示される問題を修正

### DIFF
--- a/components/MobileFixedFooter.tsx
+++ b/components/MobileFixedFooter.tsx
@@ -15,7 +15,7 @@ const MobileFixedFooter = async () => {
 
   return (
     <>
-      <div className="md:hidden sticky bottom-0 border-t shadow-2xl w-full bg-background">
+      <div className="md:hidden sticky bottom-0 border-t shadow-2xl w-full bg-background z-20">
         <div className="flex h-16">
           <Link
             href="/"


### PR DESCRIPTION
## Summary

- SP（スマートフォン）のライバー一覧ページで、お気に入りライバーを示す星マーク・ハートマークが `MobileFixedFooter`（スティッキーフッター）の上に重なって表示されていた問題を修正

## 原因

`MobileFixedFooter` に `z-index` が設定されていなかったため、`z-10` を持つ星・ハートアイコンがフッターより上に描画されていた。

## 変更内容

- `components/MobileFixedFooter.tsx`: sticky div に `z-20` を追加
  - z-index 階層: `z-10`（星/ハートアイコン）< `z-20`（フッター）< `z-50`（ヘッダー）


closes #215 

## Test plan

- [x] SP表示でライバー一覧ページを開く
- [x] お気に入りライバーに星・ハートが表示されていることを確認
- [x] ページをスクロールしてフッターが星・ハートの上に表示されることを確認
- [x] ヘッダーがフッターより上に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)