### PR TITLE
fix: リアクションボタンを押してもすぐ元に戻る不具合を修正

### DIFF
--- a/app/action/updateReaction.ts
+++ b/app/action/updateReaction.ts
@@ -2,7 +2,7 @@
 
 import prisma from "@/lib/db";
 import { Reaction } from "@/types/type";
-import { revalidateTag } from "next/cache";
+import { updateTag } from "next/cache";
 import getCurrentUser from "./getCurrentUser";
 
 // サーバーアクションは外部から任意の引数で呼び出せるため、ランタイムで許可値を検証する
@@ -57,8 +57,8 @@ const updateReaction = async (
     data: updateData,
   });
 
-  revalidateTag("get-post", "minutes");
-  revalidateTag(`get-reactions:${postId}`, "seconds");
+  updateTag("get-post");
+  updateTag(`get-reactions:${postId}`);
 };
 
 export default updateReaction;


### PR DESCRIPTION
Closes #311

## Summary

- `updateReaction` Server Action 内の `revalidateTag` を `updateTag` に変更
- `revalidateTag` は stale-while-revalidate のため変更が即座に反映されない
- `updateTag` は read-your-own-writes 向けの即時無効化で、ユーザーの操作結果がすぐUIに反映される

## Test plan

- [x] 投稿詳細画面でリアクションボタンを押すとアクティブ状態になり、元に戻らないことを確認
- [x] 再度押すとアクティブ状態が解除されることを確認
- [x] ページをリロードしてもリアクション状態が維持されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)