### PR TITLE
feat: Y4T4の8名をライバーに追加

### DIFF
--- a/app/(pages)/history/page.tsx
+++ b/app/(pages)/history/page.tsx
@@ -11,6 +11,16 @@ const Page = () => {
         <h1 className="text-3xl font-bold mb-16">更新履歴</h1>
         <div className="space-y-8">
           <div>
+            <time dateTime="2026-05-18" className="font-bold">
+              2026/05/18
+            </time>
+            <ul className="my-2 ml-6 list-disc [&>li]:mt-2">
+              <li>
+                「Rei7」「男虎」「御子神琴音」「塚原大地」「千凛あゆむ」「九里詠太」「小々波いるか」「レヨン」の8名を追加しました。
+              </li>
+            </ul>
+          </div>
+          <div>
             <time dateTime="2026-03-22" className="font-bold">
               2026/03/22
             </time>

--- a/public/liver.json
+++ b/public/liver.json
@@ -2588,5 +2588,85 @@
     "isOverseas": 0,
     "birthMonth": 10,
     "birthDate": 9
+  },
+  {
+    "name": "Rei7",
+    "aliasFirst": "れいな",
+    "aliasSecond": "",
+    "channelHandle": "@Rei7_Y4T4",
+    "isRetire": 0,
+    "isOverseas": 0,
+    "birthMonth": 7,
+    "birthDate": 27
+  },
+  {
+    "name": "男虎",
+    "aliasFirst": "おのとら",
+    "aliasSecond": "",
+    "channelHandle": "@Onotora_Y4T4",
+    "isRetire": 0,
+    "isOverseas": 0,
+    "birthMonth": 8,
+    "birthDate": 20
+  },
+  {
+    "name": "御子神琴音",
+    "aliasFirst": "みこがみことね",
+    "aliasSecond": "",
+    "channelHandle": "@MikogamiKotone_Y4T4",
+    "isRetire": 0,
+    "isOverseas": 0,
+    "birthMonth": 3,
+    "birthDate": 9
+  },
+  {
+    "name": "塚原大地",
+    "aliasFirst": "つかはらだいち",
+    "aliasSecond": "",
+    "channelHandle": "@TsukaharaDaichi_Y4T4",
+    "isRetire": 0,
+    "isOverseas": 0,
+    "birthMonth": 11,
+    "birthDate": 18
+  },
+  {
+    "name": "千凛あゆむ",
+    "aliasFirst": "せんりあゆむ",
+    "aliasSecond": "",
+    "channelHandle": "@SenriAyumu_Y4T4",
+    "isRetire": 0,
+    "isOverseas": 0,
+    "birthMonth": 1,
+    "birthDate": 5
+  },
+  {
+    "name": "九里詠太",
+    "aliasFirst": "くりえいた",
+    "aliasSecond": "",
+    "channelHandle": "@KuriEita_Y4T4",
+    "isRetire": 0,
+    "isOverseas": 0,
+    "birthMonth": 12,
+    "birthDate": 19
+  },
+  {
+    "name": "小々波いるか",
+    "aliasFirst": "ここなみいるか",
+    "aliasSecond": "",
+    "channelHandle": "@KokonamiIruka_Y4T4",
+    "isRetire": 0,
+    "isOverseas": 0,
+    "birthMonth": 9,
+    "birthDate": 12
+  },
+  {
+    "name": "レヨン",
+    "aliasFirst": "れよん",
+    "aliasSecond": "",
+    "channelHandle": "@Rayon_Y4T4",
+    "isRetire": 0,
+    "isOverseas": 0,
+    "birthMonth": 2,
+    "birthDate": 23
   }
 ]


### PR DESCRIPTION
## Summary
- にじさんじの新ストリーマーチーム「Y4T4」の8名を `public/liver.json` に追加
  - Rei7、男虎、御子神琴音、塚原大地、千凛あゆむ、九里詠太、小々波いるか、レヨン
  - 並びは [ANYCOLOR公式プレスリリース](https://prtimes.jp/main/html/rd/p/000001487.000030865.html) の紹介順
- 更新履歴ページ (`app/(pages)/history/page.tsx`) に 2026/05/18 エントリを追加

## メンバー情報の出典
| メンバー | channelHandle | 誕生日 |
|---|---|---|
| Rei7 | @Rei7_Y4T4 | 7/27 |
| 男虎 | @Onotora_Y4T4 | 8/20 |
| 御子神琴音 | @MikogamiKotone_Y4T4 | 3/9 |
| 塚原大地 | @TsukaharaDaichi_Y4T4 | 11/18 |
| 千凛あゆむ | @SenriAyumu_Y4T4 | 1/5 |
| 九里詠太 | @KuriEita_Y4T4 | 12/19 |
| 小々波いるか | @KokonamiIruka_Y4T4 | 9/12 |
| レヨン | @Rayon_Y4T4 | 2/23 |

## Test plan
- [ ] ローカルDBで `/liver_register` を開き、Y4T4 8名が差分として表示されることを確認
- [ ] グループ登録ボタンで upsert できることを確認
- [ ] 各メンバーのアイコン画像が YouTube API 経由で取得されることを確認
- [ ] `/history` ページに 2026/05/18 エントリが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)