### PR TITLE
fix: claude-code-action のモデルを claude-sonnet-5 に明示指定

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,8 +43,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "renovate" # renovateボットのみ許可
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # アクションのデフォルトモデル claude-sonnet-4-20250514 は 2026-06-15 に廃止され
+          # API が 404 を返すため、後継モデルを明示的に指定する
+          model: "claude-sonnet-5"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,8 +40,9 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # アクションのデフォルトモデル claude-sonnet-4-20250514 は 2026-06-15 に廃止され
+          # API が 404 を返すため、後継モデルを明示的に指定する
+          model: "claude-sonnet-5"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## 概要

全 PR で `claude-review` チェックが失敗している問題の修正。

## 原因

`anthropics/claude-code-action`（beta 版 SHA 固定）のデフォルトモデル `claude-sonnet-4-20250514` が 2026-06-15 に廃止され、API が 404 (`not_found_error`) を返していた。

```
API Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}}
```

## 対応

`claude-code-review.yml` と `claude.yml` の両方に後継モデル `claude-sonnet-5` を明示指定。

この PR 自体の claude-review が成功すれば修正の動作確認になるため、`[skip-review]` は付けていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)