### PR TITLE
feat: 新人ライバー「ぷりん・らら・もーど」「ぽめろ・ぱんち」の2名を追加

### DIFF
--- a/app/(pages)/history/page.tsx
+++ b/app/(pages)/history/page.tsx
@@ -11,6 +11,16 @@ const Page = () => {
         <h1 className="text-3xl font-bold mb-16">更新履歴</h1>
         <div className="space-y-8">
           <div>
+            <time dateTime="2026-07-26" className="font-bold">
+              2026/07/26
+            </time>
+            <ul className="my-2 ml-6 list-disc [&>li]:mt-2">
+              <li>
+                「ぷりん・らら・もーど」「ぽめろ・ぱんち」の2名を追加しました。
+              </li>
+            </ul>
+          </div>
+          <div>
             <time dateTime="2026-05-18" className="font-bold">
               2026/05/18
             </time>

--- a/public/liver.json
+++ b/public/liver.json
@@ -2668,5 +2668,25 @@
     "isOverseas": 0,
     "birthMonth": 2,
     "birthDate": 23
+  },
+  {
+    "name": "ぷりん・らら・もーど",
+    "aliasFirst": "ぷりん・らら・もーど",
+    "aliasSecond": "",
+    "channelHandle": "@PurinLalaMode",
+    "isRetire": 0,
+    "isOverseas": 0,
+    "birthMonth": 2,
+    "birthDate": 25
+  },
+  {
+    "name": "ぽめろ・ぱんち",
+    "aliasFirst": "ぽめろ・ぱんち",
+    "aliasSecond": "",
+    "channelHandle": "@PomeloPunch",
+    "isRetire": 0,
+    "isOverseas": 0,
+    "birthMonth": 11,
+    "birthDate": 5
   }
 ]


### PR DESCRIPTION
<!-- 日本語でレビューをしてください -->

## 概要

2026/07/21 デビューの「ぽっぷん・パーラー」2名を追加。

## 変更内容

- `public/liver.json` — 末尾に2名追加
  - ぷりん・らら・もーど（@PurinLalaMode、誕生日 2/25）
  - ぽめろ・ぱんち（@PomeloPunch、誕生日 11/5）
- `app/(pages)/history/page.tsx` — 更新履歴に 2026/07/26 のお知らせを追加

## 確認済み

- チャンネルハンドルは実チャンネルにアクセスして本人確認済み
- `/liver_register` でローカルDB登録の動作確認済み
- 本番DBへの反映済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)