### PR TITLE
fix: ローカルDBのpostgresイメージを16系に固定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: "3"
 services:
   db:
-    image: "postgres@sha256:3a82e1f56c8f0f5616a11103ac3d47e632c3938698946a7ad26da0df1334744a"
+    # 既存データ(./postgres_dev)がPostgreSQL 16のため16系に固定（18はデータ配置が非互換）
+    image: "postgres:16"
     container_name: koremina_dev
     ports:
       - "5432:5432"


### PR DESCRIPTION
<!-- 日本語でレビューをしてください -->

## 概要

ローカル開発用 Postgres（docker-compose.yml）が起動不能になっていたのを修正。

## 問題

- Renovate の digest 自動更新（直近 #392）で `postgres@sha256:…` が **PostgreSQL 18系** に到達
- 18系はデータ格納場所が変更されており、compose の `./postgres_dev:/var/lib/postgresql/data` マウントと非互換 → コンテナが即停止
- さらに既存ローカルデータは `PG_VERSION=16` のため、18系バイナリではそもそも動かない（メジャー間データ形式非互換）

## 修正

- `image: "postgres:16"` にタグ固定
- Renovate（config:best-practices の pinDigests）は今後16系タグ内で digest を pin するため、勝手にメジャーが上がる再発はなくなる。17/18系へのメジャー更新は別PRとして提示されるので、データ移行と合わせて手動判断できる

## 確認済み

- postgres:16 で既存データ（./postgres_dev）のままコンテナ起動 → `pg_isready` OK
- `/liver_register` からのライバー登録動作を確認（#418 の作業時）

🤖 Generated with [Claude Code](https://claude.com/claude-code)