### PR TITLE
fix: アバター画像の警告文を react-dropzone v19 の挙動に合わせる

### DIFF
--- a/components/feature/setting/AvatarDropZone.tsx
+++ b/components/feature/setting/AvatarDropZone.tsx
@@ -58,7 +58,7 @@ const AvatarDropZone = ({ file, setFile, disabled }: AvatarDropZoneProps) => {
       </div>
       {isError && (
         <p className="text-sm text-destructive">
-          もう一度画像を選択してください。複数選択されていたか、画像ファイルでなかった可能性があります。
+          画像ファイルではありません。もう一度選択してください。
         </p>
       )}
     </>


### PR DESCRIPTION
## 概要

react-dropzone v19 の `maxFiles` 挙動変更に合わせて `AvatarDropZone` の警告文を修正する。

> [!IMPORTANT]
> **#417（react-dropzone v19 への更新）をマージした後に取り込んでください。**
> v18 以下では複数選択時も警告が出るため、先にこの PR を入れると「複数選択されていたか」の説明が消えて誤誘導になります。

## 背景

react-dropzone v19.0.0 で `maxFiles` 超過時の扱いが変わった。

| | v18 まで | v19 |
|---|---|---|
| `acceptedFiles` / `onDropAccepted` | 空（バッチまるごと拒否） | 上限までのファイルが入る |
| `fileRejections` / `onDropRejected` | バッチ全ファイル | 上限を超えた分だけ |

`AvatarDropZone` は `acceptedFiles.length === 0` を「複数選択されていた、または画像以外だった」と解釈して警告を出していたが、v19 では複数選択しても1枚目が受理されるため `acceptedFiles` は空にならない。結果として警告が出るのは accept 不一致（画像以外のファイル）のケースだけになり、文言の「複数選択されていたか」が到達しない説明になる。

## 変更内容

警告文を変更した。

- 変更前: `もう一度画像を選択してください。複数選択されていたか、画像ファイルでなかった可能性があります。`
- 変更後: `画像ファイルではありません。もう一度選択してください。`

`maxFiles: 1` は維持している。v19 の変更は「上限を撤廃した」のではなく「上限までは受理するようになった」ものなので、1枚目だけを採用させるにはこの指定が必要。

## 動作

- 画像ファイルを1枚選択 → 従来どおり採用
- 画像ファイルを複数選択 → 1枚目を採用（警告は出さない）
- 画像以外のファイルを選択 → 警告を表示

## 補足

`app/(pages)/crop/page.tsx` も同じ `maxFiles: 1` を使っているが、そちらは `acceptedFiles` が空なら早期 return するだけで警告文を持たないため変更不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)