### PR TITLE
fix: eslint 9 の circular structure TypeError を修正

### DIFF
--- a/app/(pages)/login/page.tsx
+++ b/app/(pages)/login/page.tsx
@@ -41,7 +41,6 @@ const Page = () => {
               onClick={() => handleLogin("twitter")}
               className="rounded-full w-full"
             >
-              {/* テーマ別ロゴは CSS で切替（hydration mismatch 回避のため JS 判定しない） */}
               <Image
                 src="/x-logo-black.png"
                 alt=""

--- a/app/(pages)/login/page.tsx
+++ b/app/(pages)/login/page.tsx
@@ -2,14 +2,10 @@
 
 import { Button } from "@/components/ui/button";
 import { signIn } from "next-auth/react";
-import { useTheme } from "next-themes";
 import Image from "next/image";
 import { useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
 
 const Page = () => {
-  const [isMounted, setIsMounted] = useState(false);
-  const { resolvedTheme } = useTheme();
   const searchParams = useSearchParams();
 
   const callbackUrl = searchParams.get("callbackUrl") || undefined;
@@ -17,12 +13,6 @@ const Page = () => {
   const handleLogin = (provider: "google" | "twitter") => {
     signIn(provider, { callbackUrl });
   };
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
-  if (!isMounted) return null;
 
   return (
     <>
@@ -51,16 +41,20 @@ const Page = () => {
               onClick={() => handleLogin("twitter")}
               className="rounded-full w-full"
             >
+              {/* テーマ別ロゴは CSS で切替（hydration mismatch 回避のため JS 判定しない） */}
               <Image
-                src={
-                  resolvedTheme === "dark"
-                    ? "/x-logo-white.png"
-                    : "/x-logo-black.png"
-                }
+                src="/x-logo-black.png"
                 alt=""
                 width={16}
                 height={16}
-                className="mr-2 w-4 aspect-square"
+                className="mr-2 w-4 aspect-square dark:hidden"
+              />
+              <Image
+                src="/x-logo-white.png"
+                alt=""
+                width={16}
+                height={16}
+                className="mr-2 w-4 aspect-square hidden dark:block"
               />
               Xでログイン
             </Button>

--- a/components/FirstVisitDialog.tsx
+++ b/components/FirstVisitDialog.tsx
@@ -1,28 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
 import { Button } from "./ui/button";
 import Link from "next/link";
 
 const FirstVisitDialog = () => {
-  const [isFirstVisit, setIsFirstVisit] = useState(true);
-  const [isMounted, setIsMounted] = useState(false);
-  useEffect(() => {
-    if (!isMounted) {
-      setIsMounted(true);
-    } else {
-      if (localStorage.getItem("isFirstVisit") === "false") {
-        setIsFirstVisit(false);
-      }
-    }
-
-    return () => {
-      if (isMounted) {
-        setLocalStorage();
-      }
-    };
-  }, [isMounted]);
+  // SSR では常に false（サーバーに localStorage が無いため）。
+  // Dialog はポータル描画なので hydration mismatch は起きない
+  const [isFirstVisit, setIsFirstVisit] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      localStorage.getItem("isFirstVisit") !== "false"
+  );
 
   const setLocalStorage = () => {
     setIsFirstVisit(false);
@@ -31,7 +21,7 @@ const FirstVisitDialog = () => {
 
   return (
     <>
-      {isMounted && isFirstVisit && (
+      {isFirstVisit && (
         <Dialog defaultOpen onOpenChange={setLocalStorage}>
           <DialogContent className="sm:max-w-md max-w-[90%]">
             <DialogHeader>
@@ -50,7 +40,10 @@ const FirstVisitDialog = () => {
             </div>
             <div className="text-center mt-8">
               <Button asChild size="lg">
-                <Link href="/post">あなたのおすすめ動画を投稿する</Link>
+                {/* ダイアログを閉じずに遷移した場合も表示済みとして記録する */}
+                <Link href="/post" onClick={setLocalStorage}>
+                  あなたのおすすめ動画を投稿する
+                </Link>
               </Button>
               <p className="text-sm text-muted-foreground mt-4">
                 （GoogleもしくはXアカウントでログインできます）

--- a/components/FirstVisitDialog.tsx
+++ b/components/FirstVisitDialog.tsx
@@ -6,8 +6,6 @@ import { Button } from "./ui/button";
 import Link from "next/link";
 
 const FirstVisitDialog = () => {
-  // SSR では常に false（サーバーに localStorage が無いため）。
-  // Dialog はポータル描画なので hydration mismatch は起きない
   const [isFirstVisit, setIsFirstVisit] = useState(
     () =>
       typeof window !== "undefined" &&
@@ -40,7 +38,6 @@ const FirstVisitDialog = () => {
             </div>
             <div className="text-center mt-8">
               <Button asChild size="lg">
-                {/* ダイアログを閉じずに遷移した場合も表示済みとして記録する */}
                 <Link href="/post" onClick={setLocalStorage}>
                   あなたのおすすめ動画を投稿する
                 </Link>

--- a/components/feature/setting/FavoriteLiversList.tsx
+++ b/components/feature/setting/FavoriteLiversList.tsx
@@ -7,8 +7,6 @@ import getCurrentUserWithTag from "@/app/action/getCurrentUserWithTag";
  * データ取得を含むため、Suspenseで囲んで使用する
  */
 const FavoriteLiversList = async () => {
-  // JSX を try 内で構築するとレンダリング時エラーが catch されないため、
-  // データ取得のみを try で囲む（react-hooks/error-boundaries）
   let currentUser;
   try {
     currentUser = await getCurrentUserWithTag();

--- a/components/feature/setting/FavoriteLiversList.tsx
+++ b/components/feature/setting/FavoriteLiversList.tsx
@@ -7,38 +7,11 @@ import getCurrentUserWithTag from "@/app/action/getCurrentUserWithTag";
  * データ取得を含むため、Suspenseで囲んで使用する
  */
 const FavoriteLiversList = async () => {
+  // JSX を try 内で構築するとレンダリング時エラーが catch されないため、
+  // データ取得のみを try で囲む（react-hooks/error-boundaries）
+  let currentUser;
   try {
-    const currentUser = await getCurrentUserWithTag();
-
-    if (!currentUser) return null;
-
-    return (
-      <>
-        {currentUser.favoriteLivers.length > 0 ? (
-          <div className="grid grid-cols-[repeat(auto-fit,64px)] justify-center gap-2 w-full">
-            {currentUser.favoriteLivers
-              .toSorted((a, b) => a.index - b.index)
-              .map(liver => (
-                <Link
-                  key={liver.id}
-                  href={`/page?liver=${liver.id}`}
-                  className="rounded-full hover:opacity-70 transition-opacity"
-                >
-                  <ChannelIcon channelId={liver.channelHandle} size={64} />
-                </Link>
-              ))}
-          </div>
-        ) : (
-          <div className="text-center">
-            <p>
-              あなたの推しのライバーを設定しましょう！
-              <br />
-              何人でもOK！
-            </p>
-          </div>
-        )}
-      </>
-    );
+    currentUser = await getCurrentUserWithTag();
   } catch (error) {
     console.error("推しライバーの取得に失敗しました:", error);
     return (
@@ -47,6 +20,36 @@ const FavoriteLiversList = async () => {
       </div>
     );
   }
+
+  if (!currentUser) return null;
+
+  return (
+    <>
+      {currentUser.favoriteLivers.length > 0 ? (
+        <div className="grid grid-cols-[repeat(auto-fit,64px)] justify-center gap-2 w-full">
+          {currentUser.favoriteLivers
+            .toSorted((a, b) => a.index - b.index)
+            .map(liver => (
+              <Link
+                key={liver.id}
+                href={`/page?liver=${liver.id}`}
+                className="rounded-full hover:opacity-70 transition-opacity"
+              >
+                <ChannelIcon channelId={liver.channelHandle} size={64} />
+              </Link>
+            ))}
+        </div>
+      ) : (
+        <div className="text-center">
+          <p>
+            あなたの推しのライバーを設定しましょう！
+            <br />
+            何人でもOK！
+          </p>
+        </div>
+      )}
+    </>
+  );
 };
 
 export default FavoriteLiversList;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,11 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
+import nextTypescript from "eslint-config-next/typescript";
+import prettier from "eslint-config-prettier/flat";
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript", "prettier"),
+  ...nextCoreWebVitals,
+  ...nextTypescript,
+  prettier,
   {
     ignores: [
       "**/*.test.ts",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "zod": "^4.1.11"
   },
   "devDependencies": {
-    "@eslint/eslintrc": "3.3.6",
     "@tailwindcss/postcss": "4.3.3",
     "@testing-library/jest-dom": "7.0.0",
     "@testing-library/react": "16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,9 +138,6 @@ importers:
         specifier: ^4.1.11
         version: 4.4.3
     devDependencies:
-      '@eslint/eslintrc':
-        specifier: 3.3.6
-        version: 3.3.6
       '@tailwindcss/postcss':
         specifier: 4.3.3
         version: 4.3.3


### PR DESCRIPTION
## 概要

`pnpm lint` が `TypeError: Converting circular structure to JSON` で実行不能だった問題の修正。

## 根本原因

- eslint-config-next 16 は flat config 配列を直接エクスポートする（`/core-web-vitals`, `/typescript` サブパス）
- 旧設定は FlatCompat（eslintrc 形式専用）経由で読み込んでいたため eslintrc スキーマ検証に失敗
- その検証エラーメッセージ整形時の `JSON.stringify` が react プラグインの循環参照（`configs.flat` → `plugins.react`）で TypeError → 本来のエラーが隠蔽されクラッシュ

## 変更内容

- **eslint.config.mjs**: FlatCompat を廃止し flat config をネイティブ import（`eslint-config-next/core-web-vitals`, `eslint-config-next/typescript`, `eslint-config-prettier/flat`）
- lint 復活により react-hooks v7 の新ルールが検出した既存コードの error 8件を修正:
  - **login/page.tsx**: テーマ別 X ロゴを CSS（`dark:hidden` / `hidden dark:block`）切替に変更し、effect 内同期 setState と mount guard を削除（SSR から正しく描画されるようになる副次改善あり）
  - **FirstVisitDialog.tsx**: localStorage 読取を useState の lazy initializer 化し effect を撤廃。ダイアログ内リンク遷移時の既読記録は Link の onClick で担保
  - **FavoriteLiversList.tsx**: データ取得のみを try で囲み、JSX 構築を try 外へ移動（`react-hooks/error-boundaries` 対応）

## 検証

- `pnpm lint` → exit 0（error 0件 / warning 3件は react-hook-form `watch()` 由来の Compiler スキップ通知でライブラリ側制約）
- `npx tsc --noEmit` → エラーなし
- `pnpm test` → 39 passed / 1 suite 失敗は既知ベースライン（typedSql 未生成、本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)