### PR TITLE
fix: ライバー登録の重複レコード作成を防止

### DIFF
--- a/__tests__/normalize-liver-name.test.ts
+++ b/__tests__/normalize-liver-name.test.ts
@@ -1,0 +1,37 @@
+import { normalizeLiverName } from "../lib/normalizeLiverName";
+
+// 見た目では判別できない特殊空白を定数に隔離して使用する
+const NBSP = " ";
+const IDEOGRAPHIC_SPACE = "　";
+
+describe("normalizeLiverName", () => {
+  test("ノーブレークスペース(U+00A0)を通常スペースに正規化すること", () => {
+    expect(normalizeLiverName(`トゥイスティー${NBSP}アマノザコ`)).toBe(
+      "トゥイスティー アマノザコ"
+    );
+  });
+
+  test("全角スペース(U+3000)を通常スペースに正規化すること", () => {
+    expect(
+      normalizeLiverName(`トゥイスティー${IDEOGRAPHIC_SPACE}アマノザコ`)
+    ).toBe("トゥイスティー アマノザコ");
+  });
+
+  test("連続する空白を1つにまとめること", () => {
+    expect(normalizeLiverName("ユ  ルリ")).toBe("ユ ルリ");
+  });
+
+  test("前後の空白を除去すること", () => {
+    expect(normalizeLiverName(" 月ノ美兎 ")).toBe("月ノ美兎");
+  });
+
+  test("通常の名前はそのまま返すこと", () => {
+    expect(normalizeLiverName("ぽむ・れいんぱふ")).toBe("ぽむ・れいんぱふ");
+  });
+
+  test("表記揺れした同名同士が一致すること", () => {
+    expect(normalizeLiverName(`トゥイスティー${NBSP}アマノザコ`)).toBe(
+      normalizeLiverName("トゥイスティー アマノザコ")
+    );
+  });
+});

--- a/app/(pages)/liver_register/GroupRegisterButton.tsx
+++ b/app/(pages)/liver_register/GroupRegisterButton.tsx
@@ -46,6 +46,12 @@ const GroupRegisterButton = ({ listId }: RegisterButtonProps) => {
           case "isRetire":
             value = !!Number(value);
             break;
+          case "birthMonth":
+            value = value ? Number(value) : null;
+            break;
+          case "birthDate":
+            value = value ? Number(value) : null;
+            break;
         }
         pairs.push([key, value]);
       });

--- a/app/(pages)/liver_register/GroupRegisterButton.tsx
+++ b/app/(pages)/liver_register/GroupRegisterButton.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Liver } from "@prisma/client";
 import { Loader2 } from "lucide-react";
 import { useTransition } from "react";
+import { toast } from "sonner";
 
 interface RegisterButtonProps {
   listId?: string;
@@ -59,10 +60,14 @@ const GroupRegisterButton = ({ listId }: RegisterButtonProps) => {
       liversJSON.push(obj);
     });
 
-    console.log(liversJSON);
-
     startTransition(async () => {
-      await updateLivers(liversJSON);
+      const { count, skipped } = await updateLivers(liversJSON);
+      if (skipped > 0) {
+        toast.warning(
+          `${skipped}件をスキップしました（DBに未登録の行）。新規登録は各行の登録ボタンから行ってください。`
+        );
+      }
+      toast.success(`${count}件を更新しました。`);
     });
   };
 

--- a/app/(pages)/liver_register/page.tsx
+++ b/app/(pages)/liver_register/page.tsx
@@ -9,6 +9,7 @@ import updateLiver from "./updateLiver";
 import { ComponentPropsWithoutRef } from "react";
 import { Liver } from "@prisma/client";
 import { z } from "zod";
+import { normalizeLiverName } from "@/lib/normalizeLiverName";
 
 const Page = async () => {
   const livers = await getLivers();
@@ -16,6 +17,15 @@ const Page = async () => {
   if (process.env.NODE_ENV === "production") {
     notFound();
   }
+
+  // liver.json のどのエントリとも名前が一致しないDB行。過去に不可視文字の
+  // 表記揺れで照合が外れ、重複レコードが放置されたため明示的に警告する
+  const orphanLivers = livers.filter(
+    dbLiver =>
+      !liverData.some(
+        l => normalizeLiverName(l.name) === normalizeLiverName(dbLiver.name)
+      )
+  );
 
   return (
     <div className="px-4 w-full max-w-7xl mx-auto">
@@ -27,6 +37,24 @@ const Page = async () => {
         <br />
         ライバーを更新、登録するときはliverData.jsonで編集したのち、このページでDBのデータを更新すること。
       </p>
+      {orphanLivers.length > 0 && (
+        <div className="mb-16 border-2 border-red-600 p-4">
+          <h2 className="text-xl font-bold text-red-600 mb-2">
+            liverData.jsonに存在しないDBレコード
+          </h2>
+          <p className="mb-2 text-sm">
+            名前の表記揺れや重複登録の可能性があります。内容を確認して対処してください。
+          </p>
+          <ul className="text-sm space-y-1">
+            {orphanLivers.map(liver => (
+              <li key={liver.id}>
+                {liver.name}（id: {liver.id} / channelHandle:{" "}
+                {liver.channelHandle || "未設定"}）
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       <h2 className="text-xl font-bold mt-4 mb-2">在籍にじさんじライバー</h2>
       <GroupRegisterButton listId="nijisanji" />
       <ul id="nijisanji" className="space-y-2">
@@ -77,8 +105,14 @@ const LiverFormItem = ({
   liver: (typeof liverData)[0];
   dbLivers: Awaited<ReturnType<typeof getLivers>>;
 }) => {
-  const liver_db = livers.find(l => l.name === liver.name);
-  const isLiverDuplicate = livers.filter(l => l.name === liver.name).length > 1;
+  // 不可視文字（NBSP等）の表記揺れで照合が外れないよう正規化して比較する
+  const liver_db = livers.find(
+    l => normalizeLiverName(l.name) === normalizeLiverName(liver.name)
+  );
+  const isLiverDuplicate =
+    livers.filter(
+      l => normalizeLiverName(l.name) === normalizeLiverName(liver.name)
+    ).length > 1;
   return (
     <li
       key={liver.name}
@@ -97,11 +131,7 @@ const LiverFormItem = ({
           className="w-12"
           defaultValue={liverData.findIndex(l => l.name === liver.name)}
         />
-        <LiverFormInput
-          name="id"
-          defaultValue={livers.find(l => l.name === liver.name)?.id}
-          readOnly
-        />
+        <LiverFormInput name="id" defaultValue={liver_db?.id} readOnly />
         <LiverFormInput name="name" liverDB={liver_db} liverJSON={liver} />
         <LiverFormInput
           name="aliasFirst"

--- a/app/(pages)/liver_register/updateLiver.ts
+++ b/app/(pages)/liver_register/updateLiver.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import prisma from "@/lib/db";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, updateTag } from "next/cache";
 import { z } from "zod";
 
 const updateLiverSchema = z.object({
@@ -66,6 +66,9 @@ const updateLiver = async (formData: FormData) => {
     },
   });
 
+  // getLivers の "use cache" を即時無効化しないと、登録済みの行が
+  // 古いキャッシュ上「未登録」のままになり再クリックで重複作成される
+  updateTag("get-livers");
   revalidatePath("/liver_register");
 };
 

--- a/app/action/updateLivers.ts
+++ b/app/action/updateLivers.ts
@@ -2,14 +2,20 @@
 
 import prisma from "@/lib/db";
 import { Liver } from "@prisma/client";
+import { updateTag } from "next/cache";
 
 const updateLivers = async (liversJSON: Liver[]) => {
-  const query = liversJSON.map(l =>
-    prisma.liver.upsert({
+  // id が空の行は DB との名前照合に失敗した行。upsert すると必ず create になり
+  // 重複レコードを生むため対象から除外する（新規登録は各行の単体フォームで行う）
+  const targets = liversJSON.filter(l => l.id);
+  const skipped = liversJSON.length - targets.length;
+
+  const query = targets.map(l =>
+    prisma.liver.update({
       where: {
         id: l.id,
       },
-      update: {
+      data: {
         index: l.index,
         isRetire: l.isRetire,
         isOverseas: l.isOverseas,
@@ -17,22 +23,17 @@ const updateLivers = async (liversJSON: Liver[]) => {
         aliasFirst: l.aliasFirst,
         aliasSecond: l.aliasSecond,
         channelHandle: l.channelHandle,
-      },
-      create: {
-        index: l.index,
-        isRetire: l.isRetire,
-        isOverseas: l.isOverseas,
-        name: l.name,
-        aliasFirst: l.aliasFirst,
-        aliasSecond: l.aliasSecond,
-        channelHandle: l.channelHandle,
+        birthMonth: l.birthMonth,
+        birthDate: l.birthDate,
       },
     })
   );
 
   const result = await prisma.$transaction([...query]);
 
-  return { count: result.length };
+  updateTag("get-livers");
+
+  return { count: result.length, skipped };
 };
 
 export default updateLivers;

--- a/lib/normalizeLiverName.ts
+++ b/lib/normalizeLiverName.ts
@@ -1,0 +1,11 @@
+/**
+ * ライバー名の照合用に正規化する。
+ *
+ * 過去に liver.json とDBの間でノーブレークスペース(U+00A0)と
+ * 通常スペースの表記揺れが発生し、名前照合の失敗により
+ * 本番DBへ重複レコードが作成された。見た目が同じでも内部表現が
+ * 異なる文字列同士を一致させるため、NFKC 正規化と空白類の統一を
+ * 行ってから比較すること。
+ */
+export const normalizeLiverName = (name: string): string =>
+  name.normalize("NFKC").replace(/\s+/g, " ").trim();


### PR DESCRIPTION
## 概要

本番DBで「トゥイスティー アマノザコ」が2人表示されていた不具合の再発防止。

## 原因（調査結果）

- 初期データの name にノーブレークスペース（U+00A0）が混入しており、その後 liver.json 側だけ通常スペースに正規化された
- `/liver_register` の id 補完は name 完全一致のため照合が外れ、id が空文字に
- `upsert({ where: { id: "" } })` は必ずミスして create → 重複レコード誕生
- `getLivers` の `use cache`（hours）を無効化する処理が無く、登録後も古い一覧のままで再クリック時の二重 create も誘発

※ 本番DBの重複行は調査時に統合削除済み（お気に入り3件は正規行へ移行、Liver総数 269 = liver.json と一致）。

## 変更内容

- `lib/normalizeLiverName.ts`: NFKC + 空白統一の照合用正規化ヘルパーを追加（テスト付き）
- `page.tsx`: name 照合を正規化比較に変更、liver.json に存在しないDB孤児行の警告表示を追加
- `updateLivers.ts`: id 空行はスキップ（意図せぬ create の根絶）、`updateTag("get-livers")` で即時キャッシュ無効化、birthMonth/birthDate の更新漏れ修正
- `updateLiver.ts`: `updateTag("get-livers")` 追加
- `GroupRegisterButton.tsx`: birthMonth/birthDate の数値変換追加（文字列のまま送ると Prisma で実行時エラー）

## 検証

- 新規テスト 6 件パス、既存テスト・lint・tsc は既知ベースラインと差分なし
- ローカルDB（本番コピー）+ dev サーバーで NBSP 行への id 補完・重複赤枠・孤児警告の表示を実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)